### PR TITLE
reorganize project structure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# Build Stage
+FROM lacion/alpine-golang-buildimage:1.13 AS build-stage
+
+LABEL app="build-clairvoyance"
+LABEL REPO="https://github.com/mpmsimo/clairvoyance"
+
+ENV PROJPATH=/go/src/github.com/mpmsimo/clairvoyance
+
+# Because of https://github.com/docker/docker/issues/14914
+ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+
+ADD . /go/src/github.com/mpmsimo/clairvoyance
+WORKDIR /go/src/github.com/mpmsimo/clairvoyance
+
+RUN make build-alpine
+
+# Final Stage
+FROM lacion/alpine-base-image:latest
+
+ARG GIT_COMMIT
+ARG VERSION
+LABEL REPO="https://github.com/mpmsimo/clairvoyance"
+LABEL GIT_COMMIT=$GIT_COMMIT
+LABEL VERSION=$VERSION
+
+# Because of https://github.com/docker/docker/issues/14914
+ENV PATH=$PATH:/opt/clairvoyance/bin
+
+WORKDIR /opt/clairvoyance/bin
+
+COPY --from=build-stage /go/src/github.com/mpmsimo/clairvoyance/bin/clairvoyance /opt/clairvoyance/bin/
+RUN chmod +x /opt/clairvoyance/bin/clairvoyance
+
+# Create appuser
+RUN adduser -D -g '' clairvoyance
+USER clairvoyance
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+
+CMD ["/opt/clairvoyance/bin/clairvoyance"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,64 @@
+
+.PHONY: build build-alpine clean test help default
+
+
+
+BIN_NAME=clairvoyance
+
+VERSION := $(shell grep "const Version " version/version.go | sed -E 's/.*"(.+)"$$/\1/')
+GIT_COMMIT=$(shell git rev-parse HEAD)
+GIT_DIRTY=$(shell test -n "`git status --porcelain`" && echo "+CHANGES" || true)
+BUILD_DATE=$(shell date '+%Y-%m-%d-%H:%M:%S')
+IMAGE_NAME := "mpmsimo/clairvoyance"
+
+default: test
+
+help:
+	@echo 'Management commands for clairvoyance:'
+	@echo
+	@echo 'Usage:'
+	@echo '    make build           Compile the project.'
+	@echo '    make get-deps        runs dep ensure, mostly used for ci.'
+	@echo '    make build-alpine    Compile optimized for alpine linux.'
+	@echo '    make package         Build final docker image with just the go binary inside'
+	@echo '    make tag             Tag image created by package with latest, git commit and version'
+	@echo '    make test            Run tests on a compiled project.'
+	@echo '    make push            Push tagged images to registry'
+	@echo '    make clean           Clean the directory tree.'
+	@echo
+
+build:
+	@echo "building ${BIN_NAME} ${VERSION}"
+	@echo "GOPATH=${GOPATH}"
+	go build -ldflags "-X github.com/mpmsimo/clairvoyance/version.GitCommit=${GIT_COMMIT}${GIT_DIRTY} -X github.com/mpmsimo/clairvoyance/version.BuildDate=${BUILD_DATE}" -o bin/${BIN_NAME}
+
+get-deps:
+	dep ensure
+
+build-alpine:
+	@echo "building ${BIN_NAME} ${VERSION}"
+	@echo "GOPATH=${GOPATH}"
+	go build -ldflags '-w -linkmode external -extldflags "-static" -X github.com/mpmsimo/clairvoyance/version.GitCommit=${GIT_COMMIT}${GIT_DIRTY} -X github.com/mpmsimo/clairvoyance/version.BuildDate=${BUILD_DATE}' -o bin/${BIN_NAME}
+
+package:
+	@echo "building image ${BIN_NAME} ${VERSION} $(GIT_COMMIT)"
+	docker build --build-arg VERSION=${VERSION} --build-arg GIT_COMMIT=$(GIT_COMMIT) -t $(IMAGE_NAME):local .
+
+tag: 
+	@echo "Tagging: latest ${VERSION} $(GIT_COMMIT)"
+	docker tag $(IMAGE_NAME):local $(IMAGE_NAME):$(GIT_COMMIT)
+	docker tag $(IMAGE_NAME):local $(IMAGE_NAME):${VERSION}
+	docker tag $(IMAGE_NAME):local $(IMAGE_NAME):latest
+
+push: tag
+	@echo "Pushing docker image to registry: latest ${VERSION} $(GIT_COMMIT)"
+	docker push $(IMAGE_NAME):$(GIT_COMMIT)
+	docker push $(IMAGE_NAME):${VERSION}
+	docker push $(IMAGE_NAME):latest
+
+clean:
+	@test ! -e bin/${BIN_NAME} || rm bin/${BIN_NAME}
+
+test:
+	go test ./...
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,21 @@
 # clairvoyance
+
 Drift detection and reporting for Terraform.
 
-## Installation
-### Project Setup
-Install `terraform-exec` so we can init/plan/apply via the Terraform CLI programmatically.
-`go get github.com/kmoe/terraform-exec`
+## Getting started
+
+This project requires Go to be installed. On OS X with Homebrew you can just run `brew install go`.
+
+Running it then should be as simple as:
+
+```console
+$ make
+$ ./bin/clairvoyance
+```
+
+### Testing
+``make test``
+
+
+## Additional Information
+Repository was initially bootstrapped with [cookiecutter-golang](https://github.com/lacion/cookiecutter-golang).

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var cfgFile string
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "generated code example",
+	Short: "A brief description of your application",
+	Long: `A longer description that spans multiple lines and likely contains
+examples and usage of using your application. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	// Uncomment the following line if your bare application
+	// has an action associated with it:
+	//      Run: func(cmd *cobra.Command, args []string) { },
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	cobra.OnInitialize()
+
+	// Cobra also supports local flags, which will only run
+	// when this action is called directly.
+	// rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/mpmsimo/clairvoyance/version"
+	"github.com/spf13/cobra"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number of generated code example",
+	Long:  `All software has versions. This is generated code example`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Build Date:", version.BuildDate)
+		fmt.Println("Git Commit:", version.GitCommit)
+		fmt.Println("Version:", version.Version)
+		fmt.Println("Go Version:", version.GoVersion)
+		fmt.Println("OS / Arch:", version.OsArch)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+// Provider defines a set of read-only methods for accessing the application
+// configuration params as defined in one of the config files.
+type Provider interface {
+	ConfigFileUsed() string
+	Get(key string) interface{}
+	GetBool(key string) bool
+	GetDuration(key string) time.Duration
+	GetFloat64(key string) float64
+	GetInt(key string) int
+	GetInt64(key string) int64
+	GetSizeInBytes(key string) uint
+	GetString(key string) string
+	GetStringMap(key string) map[string]interface{}
+	GetStringMapString(key string) map[string]string
+	GetStringMapStringSlice(key string) map[string][]string
+	GetStringSlice(key string) []string
+	GetTime(key string) time.Time
+	InConfig(key string) bool
+	IsSet(key string) bool
+}
+
+var defaultConfig *viper.Viper
+
+// Config returns a default config providers
+func Config() Provider {
+	return defaultConfig
+}
+
+// LoadConfigProvider returns a configured viper instance
+func LoadConfigProvider(appName string) Provider {
+	return readViperConfig(appName)
+}
+
+func init() {
+	defaultConfig = readViperConfig("CLAIRVOYANCE")
+}
+
+func readViperConfig(appName string) *viper.Viper {
+	v := viper.New()
+	v.SetEnvPrefix(appName)
+	v.AutomaticEnv()
+
+	// global defaults
+	
+	v.SetDefault("json_logs", false)
+	v.SetDefault("loglevel", "debug")
+	
+
+	return v
+}

--- a/example.go
+++ b/example.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	tfexec "github.com/kmoe/terraform-exec"
+)
+
+func main() {
+	workingDir := os.Getenv("GOPATH") + "/src/github.com/kmoe/terraform-exec/testdata"
+
+	// Run `terraform init` so that the working directories state can be initialized.
+	err := tfexec.Init(workingDir)
+	if err != nil {
+		panic(err)
+	}
+
+	// Run `terraform show` against the state defined in the working directory.
+	state, err := tfexec.Show(workingDir)
+	if err != nil {
+		panic(err)
+	}
+
+	// Print all returned values from the `terraform show` command (of type *tfjson.State)
+	fmt.Println(state.FormatVersion) // "0.1"
+	fmt.Println(state.TerraformVersion)
+	fmt.Println(state.Values)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/mpmsimo/clairvoyance
+
+require (
+	github.com/sirupsen/logrus v1.4.1
+	github.com/spf13/cobra v0.0.3
+	github.com/spf13/viper v1.3.2
+)

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,216 @@
+package log
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/mpmsimo/clairvoyance/config"
+)
+
+// Logger defines a set of methods for writing application logs. Derived from and
+// inspired by logrus.Entry.
+type Logger interface {
+	Debug(args ...interface{})
+	Debugf(format string, args ...interface{})
+	Debugln(args ...interface{})
+	Error(args ...interface{})
+	Errorf(format string, args ...interface{})
+	Errorln(args ...interface{})
+	Fatal(args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Fatalln(args ...interface{})
+	Info(args ...interface{})
+	Infof(format string, args ...interface{})
+	Infoln(args ...interface{})
+	Panic(args ...interface{})
+	Panicf(format string, args ...interface{})
+	Panicln(args ...interface{})
+	Print(args ...interface{})
+	Printf(format string, args ...interface{})
+	Println(args ...interface{})
+	Warn(args ...interface{})
+	Warnf(format string, args ...interface{})
+	Warning(args ...interface{})
+	Warningf(format string, args ...interface{})
+	Warningln(args ...interface{})
+	Warnln(args ...interface{})
+}
+
+var defaultLogger *logrus.Logger
+
+func init() {
+	defaultLogger = newLogrusLogger(config.Config())
+}
+
+
+// NewLogger returns a configured logrus instance
+func NewLogger(cfg config.Provider) *logrus.Logger {
+	return newLogrusLogger(cfg)
+}
+
+
+
+func newLogrusLogger(cfg config.Provider) *logrus.Logger {
+
+	l := logrus.New()
+	
+	if cfg.GetBool("json_logs") {
+		l.Formatter = new(logrus.JSONFormatter)
+	}
+	l.Out = os.Stderr
+
+	switch cfg.GetString("loglevel") {
+	case "debug":
+		l.Level = logrus.DebugLevel
+	case "warning":
+		l.Level = logrus.WarnLevel
+	case "info":
+		l.Level = logrus.InfoLevel
+	default:
+		l.Level = logrus.DebugLevel
+	}
+	
+	return l
+}
+
+// Fields is a map string interface to define fields in the structured log
+type Fields map[string]interface{}
+
+// With allow us to define fields in out structured logs
+func (f Fields) With(k string, v interface{}) Fields {
+	f[k] = v
+	return f
+}
+
+// WithFields allow us to define fields in out structured logs
+func (f Fields) WithFields(f2 Fields) Fields {
+	for k, v := range f2 {
+		f[k] = v
+	}
+	return f
+}
+
+// WithFields allow us to define fields in out structured logs
+func WithFields(fields Fields) Logger {
+	return defaultLogger.WithFields(logrus.Fields(fields))
+}
+
+// Debug package-level convenience method.
+func Debug(args ...interface{}) {
+	defaultLogger.Debug(args...)
+}
+
+// Debugf package-level convenience method.
+func Debugf(format string, args ...interface{}) {
+	defaultLogger.Debugf(format, args...)
+}
+
+// Debugln package-level convenience method.
+func Debugln(args ...interface{}) {
+	defaultLogger.Debugln(args...)
+}
+
+// Error package-level convenience method.
+func Error(args ...interface{}) {
+	defaultLogger.Error(args...)
+}
+
+// Errorf package-level convenience method.
+func Errorf(format string, args ...interface{}) {
+	defaultLogger.Errorf(format, args...)
+}
+
+// Errorln package-level convenience method.
+func Errorln(args ...interface{}) {
+	defaultLogger.Errorln(args...)
+}
+
+// Fatal package-level convenience method.
+func Fatal(args ...interface{}) {
+	defaultLogger.Fatal(args...)
+}
+
+// Fatalf package-level convenience method.
+func Fatalf(format string, args ...interface{}) {
+	defaultLogger.Fatalf(format, args...)
+}
+
+// Fatalln package-level convenience method.
+func Fatalln(args ...interface{}) {
+	defaultLogger.Fatalln(args...)
+}
+
+// Info package-level convenience method.
+func Info(args ...interface{}) {
+	defaultLogger.Info(args...)
+}
+
+// Infof package-level convenience method.
+func Infof(format string, args ...interface{}) {
+	defaultLogger.Infof(format, args...)
+}
+
+// Infoln package-level convenience method.
+func Infoln(args ...interface{}) {
+	defaultLogger.Infoln(args...)
+}
+
+// Panic package-level convenience method.
+func Panic(args ...interface{}) {
+	defaultLogger.Panic(args...)
+}
+
+// Panicf package-level convenience method.
+func Panicf(format string, args ...interface{}) {
+	defaultLogger.Panicf(format, args...)
+}
+
+// Panicln package-level convenience method.
+func Panicln(args ...interface{}) {
+	defaultLogger.Panicln(args...)
+}
+
+// Print package-level convenience method.
+func Print(args ...interface{}) {
+	defaultLogger.Print(args...)
+}
+
+// Printf package-level convenience method.
+func Printf(format string, args ...interface{}) {
+	defaultLogger.Printf(format, args...)
+}
+
+// Println package-level convenience method.
+func Println(args ...interface{}) {
+	defaultLogger.Println(args...)
+}
+
+// Warn package-level convenience method.
+func Warn(args ...interface{}) {
+	defaultLogger.Warn(args...)
+}
+
+// Warnf package-level convenience method.
+func Warnf(format string, args ...interface{}) {
+	defaultLogger.Warnf(format, args...)
+}
+
+// Warning package-level convenience method.
+func Warning(args ...interface{}) {
+	defaultLogger.Warning(args...)
+}
+
+// Warningf package-level convenience method.
+func Warningf(format string, args ...interface{}) {
+	defaultLogger.Warningf(format, args...)
+}
+
+// Warningln package-level convenience method.
+func Warningln(args ...interface{}) {
+	defaultLogger.Warningln(args...)
+}
+
+// Warnln package-level convenience method.
+func Warnln(args ...interface{}) {
+	defaultLogger.Warnln(args...)
+}

--- a/main.go
+++ b/main.go
@@ -1,49 +1,13 @@
 package main
 
 import (
-    "fmt"
-    tfjson "github.com/hashicorp/terraform-json"
-    tfexec "github.com/kmoe/terraform-exec"
+	
+	"github.com/mpmsimo/clairvoyance/cmd"
 )
 
-// Figure out what statefiles need to be parsed
-var BasePath string = "/Users/mpmsimo/noobshack/"
-var ProjectName string = "valorant"
-var StateSubPath string = "/terraform"
-var workingDir string = BasePath + ProjectName + StateSubPath
-
-func initializeProjectState() () {
-    err := tfexec.Init(workingDir)
-    if err != nil {
-        panic(err)
-    }
-    fmt.Println("Project has been initialized.")
-}
-
-// For each terraform project, parse the state values
-func getProjectState() (*tfjson.State) {
-    // terraform show
-    state, err := tfexec.Show(workingDir)
-    if err != nil {
-        panic(err)
-    }
-
-    return state
-}
-
-// Record the output to be sent to Discord
-func sendProjectState(projectState *tfjson.State) {
-    // Output retrieved data
-    fmt.Println("Displaying project: " + ProjectName)
-    fmt.Println("Format Version: " + projectState.FormatVersion)
-    fmt.Println("Terraform Version: " + projectState.TerraformVersion)
-    fmt.Println("State Values: ")
-    fmt.Println(projectState.Values)
-}
-
-// TODO: Compare statefile to live resources and output drift
 func main() {
-    initializeProjectState()
-    projectState := getProjectState()
-    sendProjectState(projectState)
+
+    
+    cmd.Execute()
+	
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,21 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// GitCommit returns the git commit that was compiled. This will be filled in by the compiler.
+var GitCommit string
+
+// Version returns the main version number that is being run at the moment.
+const Version = "0.1.0"
+
+// BuildDate returns the date the binary was built
+var BuildDate = ""
+
+// GoVersion returns the version of the go runtime used to compile the binary
+var GoVersion = runtime.Version()
+
+// OsArch returns the os and arch used to build the binary
+var OsArch = fmt.Sprintf("%s %s", runtime.GOOS, runtime.GOARCH)


### PR DESCRIPTION
Change from a flat file, to a more modern golang application structure.

Taking best practices from `cookiecutter-golang` in this case. Will be modifying the repo in the future as tooling changes.