### PR TITLE
formatting: Added several discord supported formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # clairvoyance
 Drift detection and reporting for Terraform.
 
-Repository was bootstrapped with [cookiecutter-golang](https://github.com/lacion/cookiecutter-golang).
+Currently, the software does the following:
+- Initializes and inspection of a Terraform Project
+- Reporting to a Discord text channel via webhook
 
-## Getting started
-This project requires Go to be installed. On OS X with Homebrew you can just run `brew install go`.
+In the future I would like to support:
+- Planning multiple states across backends
+- Terraform project detection (local file, atlantis.yaml, Terraform Cloud workspaces)
+- Terraform Report stats (added/changed/deleted, total projects, versions, etc)
+- Clarivoyance metadata (how long it takes for a plan or report to be completed + app metrics)
+- Generate HCL code suggestions
 
 ### Project setup
-This project requires Go to be installed. 
-
-On OS X with Homebrew you can just run `brew install go`.
-
-
-Directory structure:
-
+The project is structured in the following way
 ```
 app/            - Custom clairvoyance code
   terraform/        - Helpers based on terraform-exec
@@ -24,10 +24,23 @@ log/            - Logrus log settings
 version/        - Application versioning
 ```
 
-## Development
-### Modules
-To reinitialize the modules and recreate the dependancy tree the following can be done:
+## Usage
+### Setting Environment variables
+The following environment variables will need to be set for `clairvoyance` to run:
+- `DISCORD_WEBHOOK_SECRET`
 
+The Discord secret expects to contain everything after the webhooks route:
+`https://discordapp.com/api/webhooks/$DISCORD_WEBHOOK_SECRET`
+
+### Running
+See Development/Build and Run below
+
+## Development
+This project requires Go to be installed. 
+On OS X with Homebrew you can just run `brew install go`.
+
+### Modules
+To reinitialize the modules and recreate the dependency tree the following can be done:
 ```
 cd $GOPATH/src/clairvoyance
 rm go.mod go.sum
@@ -37,10 +50,10 @@ go mod tidy
 
 ### Testing
 From the root directory you can run:
-
-``make test``
+`make test`
 
 Currently there are no tests...
+However, test driven development should is the way to go forward for this project.
 
 ### Build and Run
 Run the binary after it's been packaged:
@@ -49,12 +62,15 @@ $ make build
 $ ./bin/clairvoyance
 ```
 
+## Additional information
+This repository was bootstrapped with [cookiecutter-golang](https://github.com/lacion/cookiecutter-golang).
+
 ### Notable packages
 Packages can be downloaded from public GitHub repositories, like so:
-`https://github.com/$USER/$REPO`
+`go get https://github.com/$USER/$REPO`
 
 Modules that are intended to be used are documented below.
-- [tfvar](https://github.com/shihanng/tfvar) - programatic definition and generation of variables based on user input
 - [hclwrite](https://github.com/hashicorp/hcl/tree/v2.0.0/hclwrite) - write HCL on the fly
-- [terraform-exec](https://github.com/kmoe/terraform-exec) - so we can init/plan/apply via the Terraform CLI programmatically.
 - [terrafmt](https://github.com/terrycain/terrafmt) - format the HCL output, if live update is used
+- [terraform-exec](https://github.com/kmoe/terraform-exec) - so we can init/plan/apply via the Terraform CLI programmatically.
+- [tfvar](https://github.com/shihanng/tfvar) - programatic definition and generation of variables based on user input

--- a/app/reporting/discord.go
+++ b/app/reporting/discord.go
@@ -21,18 +21,13 @@ var (
 	ContentType string = "application/json"
 )
 
-// TODO: Gather then format Terraform drift report results
-//var report = map[string]string{"content": "hello world from Clairvoyance! content!", "message": "hw from cv - message!"}
-//var reportJSON, _ := json.Marshal(report)
-//var reportString string = "Clairvoyance says hello to this world."
-
-func SendReport() {
+func SendReport(message string) {
 	// Populate the JSON payload and Marshall data for request
-	reportString := map[string]string{
-		"content": "Hello discord!",
+	webhookData := map[string]string{
+		"content": message,
 		"username": "clairvoyance",
 	}
-	reportJSON, err := json.Marshal(reportString)
+	data, err := json.Marshal(webhookData)
 
 	// Create the HTTP socket
 	timeout := time.Duration(10 * time.Second)
@@ -45,7 +40,7 @@ func SendReport() {
 	params.Set("wait", "true")
 
 	// Format and send the HTTP request
-	request, err := http.NewRequest("POST", DiscordWebhookURL, bytes.NewBuffer(reportJSON))
+	request, err := http.NewRequest("POST", DiscordWebhookURL, bytes.NewBuffer(data))
 	request.Header.Set("Content-Type", ContentType)
 	request.Header.Set("X-Custom-Header", "clairvoyance")
 	request.Header.Set("Content-Length", strconv.Itoa(len(params.Encode())))

--- a/app/reporting/formatting.go
+++ b/app/reporting/formatting.go
@@ -1,0 +1,46 @@
+package reporting
+
+import (
+	"fmt"
+
+	"clairvoyance/log"
+)
+
+func FormatCodeBlock(message string) string {
+	return fmt.Sprintf("\n```\n%s\n```", message)
+}
+
+func FormatDriftReport(message string) string {
+	var formattedMessage string = fmt.Sprintf("Terraform Drift Detection Report"+
+		"\n"+
+		"```"+
+		"%s"+
+		"```",
+		message)
+
+	log.Printf("formatting - Formatted message.\n%s", formattedMessage)
+	return formattedMessage
+}
+
+func DebugFormatMessage() string {
+	formattedMessage := "Syntax check:" +
+		"\n" +
+		"```" +
+		"code" +
+		"block" +
+		"```" +
+		"> indent" +
+		"*bold*" +
+		"_italics_" +
+		"\n - do you need to new line?" +
+		"`single line code` " +
+		"```" +
+		"I used to be plat" +
+		"\n" +
+		"but now I am gold" +
+		"```"
+
+	log.Printf("formatting - Debug format message:\n%s", formattedMessage)
+	return formattedMessage
+}
+

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -1,26 +1,51 @@
 package cmd
 
 import (
+	"clairvoyance/log"
 	"fmt"
 
 	"github.com/spf13/cobra"
 
 	"clairvoyance/app/reporting"
+	"clairvoyance/app/terraform"
 )
 
 var reportCmd = &cobra.Command{
 	Use:   "report",
 	Short: "Reports terraform drift to Discord",
-	Long: `Usage:
-            clairvoyance report
+	Long: `Reports terraform drift to Discord
+		Usage:
+		clairvoyance report`,
 
-		   Sends a drift report to Discord.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		reporting.SendReport()
-	},
+			// TODO: Implement parsing of atlantis.yaml to know where to search for Terraform projects
+			tfexecCfg := terraform.Configure()
+			terraform.Init(tfexecCfg)
+			tfState := terraform.Show(tfexecCfg)
+
+			outputs := tfState.Values.Outputs
+			log.Info("Outputs:\n")
+			log.Info(outputs)
+
+			message := fmt.Sprintf("Project: [%s] is running version Terraform %s.", tfexecCfg.WorkingDir, tfState.TerraformVersion)
+			log.Info("Message:\n")
+			log.Info(message)
+			var sendMessage string
+
+			optDebug, _ := cmd.Flags().GetBool("debug")
+			if optDebug {
+				sendMessage = reporting.DebugFormatMessage()
+			} else {
+				sendMessage = reporting.FormatDriftReport(message)
+			}
+			log.Info("SendMessage:\n")
+			log.Info(sendMessage)
+			reporting.SendReport(sendMessage)
+		},
 }
 
 func init() {
 	fmt.Println("cmd/report/go running.")
 	rootCmd.AddCommand(reportCmd)
+	reportCmd.Flags().BoolP("debug", "d", false, "Sends a debug message to the channel instead of the drift report.")
 }


### PR DESCRIPTION
Add the following templates for sending a message to Discord:
- codeblock
- Terraform Drift report (glorified codeblock with a header)
- debug

Update the `clairvoyance report` command with a `--debug` option.

This was used in order to see if the Discord API supported markdown like they do in their client.
I'm glad they do!